### PR TITLE
Mirgrate to akka typed 2.5.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .DS_Store
 .cache
 .classpath

--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,8 @@ scalaVersion := "2.12.3"
 enablePlugins(ProtobufPlugin)
 
 lazy val akkaVersion = "2.5.6"
-lazy val akkaTypedVersion = "2.5.7-M1"
+lazy val akkaTypedVersion = "2.5.7"
 lazy val cassandraPluginVersion = "0.56"
-
-resolvers += "Akka Snapshots" at "https://repo.akka.io/snapshots/"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-typed" % akkaTypedVersion,
@@ -23,10 +21,9 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-persistence-cassandra" % cassandraPluginVersion,
   // this allows us to start cassandra from the sample
   "com.typesafe.akka" %% "akka-persistence-cassandra-launcher" % cassandraPluginVersion,
-  
-  
+
   "com.typesafe.akka" %% "akka-typed-testkit" % akkaTypedVersion  % "test",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+  "org.scalatest" %% "scalatest" % "3.0.4" % "test",
   "junit" % "junit" % "4.12" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test"
 )

--- a/src/main/scala/blog/typed/cluster/scaladsl/BlogPostBot.scala
+++ b/src/main/scala/blog/typed/cluster/scaladsl/BlogPostBot.scala
@@ -22,7 +22,7 @@ object BlogPostBot {
   private case class InternalAddPostDone(postId: String) extends BotMessage
   private case object InternalDone extends BotMessage
 
-  def behavior(): Behavior[BotMessage] =
+  def behavior: Behavior[BotMessage] =
     Actor.deferred[BotMessage] { ctx ⇒
 
       val sharding = ClusterSharding(ctx.system)

--- a/src/main/scala/blog/typed/cluster/scaladsl/ClusterShardingBlogPostApp.scala
+++ b/src/main/scala/blog/typed/cluster/scaladsl/ClusterShardingBlogPostApp.scala
@@ -5,17 +5,11 @@ import java.util.concurrent.CountDownLatch
 
 import akka.actor.ActorSystem
 import akka.persistence.cassandra.testkit.CassandraLauncher
-import com.typesafe.config.{ Config, ConfigFactory }
-
-import akka.typed.scaladsl.adapter._
-import akka.typed.cluster.Cluster
-import akka.typed.cluster.sharding.ClusterSharding
-import blog.typed.persistence.scaladsl.BlogPost
 import akka.typed.Props
-import akka.typed.cluster.sharding.ClusterShardingSettings
-import blog.typed.persistence.scaladsl.BlogCommand
-import blog.typed.persistence.scaladsl.BlogCommand
-import blog.typed.persistence.scaladsl.PassivatePost
+import akka.typed.cluster.sharding.{ClusterSharding, ClusterShardingSettings}
+import akka.typed.scaladsl.adapter._
+import blog.typed.persistence.scaladsl.{BlogCommand, BlogPost, PassivatePost}
+import com.typesafe.config.{Config, ConfigFactory}
 
 object ClusterShardingBlogPostApp {
 

--- a/src/main/scala/blog/typed/persistence/scaladsl/BlogPost1.scala
+++ b/src/main/scala/blog/typed/persistence/scaladsl/BlogPost1.scala
@@ -1,7 +1,7 @@
 package blog.typed.persistence.scaladsl
 
-import akka.typed.persistence.scaladsl.PersistentActor
 import akka.typed.Behavior
+import akka.typed.persistence.scaladsl.PersistentActor
 
 object BlogPost1 {
 
@@ -9,8 +9,8 @@ object BlogPost1 {
     PersistentActor.immutable[BlogCommand, BlogEvent, BlogState](
       persistenceId = "abc",
       initialState = BlogState.empty,
-      actions = PersistentActor.Actions { (ctx, cmd, state) ⇒ ??? },
-      applyEvent = (evt, state) ⇒ ???)
+      commandHandler = PersistentActor.CommandHandler { (ctx, state, cmd) ⇒ ??? },
+      eventHandler = (state, evt) ⇒ ???)
 
 }
 


### PR DESCRIPTION
I updated the source code to work with akka-typed 2.5.7.

Since the blog post uses the 2.5.7-M1 API, may a short notice about the changes (or even a new blog post) would be helpful. Or just discard this pull request to avoid confusion. I'm not sure how to handle the relation between blog post and this repository.

Kind regards,
Jentsch